### PR TITLE
Feature/delete format string

### DIFF
--- a/ttl_merge.py
+++ b/ttl_merge.py
@@ -25,7 +25,6 @@ def main():
         input_url = 'https://www.youtube.com/@boromaru'  # 動画のURL
 
 
-
         # ---------------------------
         # 2. 動画URLリストの取得
         # ---------------------------

--- a/ttl_merge.py
+++ b/ttl_merge.py
@@ -20,10 +20,10 @@ def main():
         # ---------------------------
         # 1. 初期設定
         # ---------------------------
+        format_code = '0'
         download_dir = 'dl'  # ダウンロードディレクトリ
         input_url = 'https://www.youtube.com/@boromaru'  # 動画のURL
-        easy_setting = True
-        format_code = '0' if easy_setting else '00634'  # 簡単設定 or 動画形式, 画質, 音声形式, 音質, コーデック
+
 
 
         # ---------------------------
@@ -33,6 +33,7 @@ def main():
         if not video_urls:
             print("動画URLの取得に失敗しました。")
             sys.exit(1)
+        
 
         # ---------------------------
         # 3. 各動画を順次処理

--- a/utl2_1_format_map.py
+++ b/utl2_1_format_map.py
@@ -1,74 +1,6 @@
 # utl2_1_format_map.py
 
-# 動画形式のマッピング 0
-VIDEO_FORMATS = {
-    '0': 'mp4',    # MPEG-4 Part 14
-    '1': 'webm',   # WebM format
-    '2': 'flv',    # Flash Video
-    '3': 'mkv',    # Matroska Video
-    '4': 'avi',    # Audio Video Interleave
-    '5': 'mov',    # QuickTime File Format
-    '6': 'wmv',    # Windows Media Video
-    '7': 'mpeg4',  # MPEG-4 Part 2
-    '8': '3gp',    # 3GPP format
-    '9': 'mpeg',   # MPEG-1 or MPEG-2
-}
-
-# 動画の画質のマッピング 1
-VIDEO_RESOLUTIONS = {
-    '0': '144',
-    '1': '240',
-    '2': '360',
-    '3': '480',
-    '4': '720',
-    '5': '1080',
-    '6': '1440',
-    '7': '2160',
-    '8': '4320',
-}
-
-# 音声形式のマッピング 2
-AUDIO_FORMATS = {
-    '0': 'flac',    # Free Lossless Audio Codec - 最も高品質な無損失音声形式
-    '1': 'mp3',     # MPEG-1 Audio Layer III - 最も汎用性が高い音声形式
-    '2': 'aac',     # Advanced Audio Coding - 高圧縮効率と高音質を両立
-    '3': 'wav',     # Waveform Audio File Format - 無圧縮の高品質音声形式
-    '4': 'opus',    # Opus Interactive Audio Codec - 高効率で低遅延のオープン音声形式
-    '5': 'ogg',     # Ogg Vorbis - オープンソースの音声圧縮形式
-    '6': 'm4a',     # MPEG-4 Audio - AACを含むコンテナ形式
-    '7': 'alac',    # Apple Lossless Audio Codec - Apple製の無損失音声形式
-    '8': 'aiff',    # Audio Interchange File Format - Apple製の非圧縮音声形式
-    '9': 'wma',     # Windows Media Audio - Microsoft製の音声圧縮形式
-}
-
-# 音声の音質のマッピング 3
-AUDIO_QUALITIES = {
-    '1': '64k',
-    '2': '96k',
-    '3': '128k',
-    '4': '160k',
-    '5': '192k',
-    '6': '256k',
-    '7': '320k',
-    '8': '384k',
-}
-
-# コーデックのマッピング 4
-CODECS = {
-    '0': 'h264',    # Advanced Video Coding (AVC) - 最も広く使用されているビデオコーデック
-    '1': 'h265',    # High Efficiency Video Coding (HEVC) - h264の後継で高い圧縮効率
-    '2': 'vp8',     # VP8 - オープンソースのビデオコーデック、主にWeb向け
-    '3': 'vp9',     # VP9 - VP8の後継で、さらに高い圧縮効率を提供
-    '4': 'av1',     # AV1 - 次世代のオープンソースコーデック、HEVCに匹敵する圧縮効率
-    '5': 'theora',  # Theora - オープンソースのビデオコーデック、主にWeb用途
-    '6': 'mpeg4',   # MPEG-4 Part 2 - 広く使用されている古典的なビデオコーデック
-    '7': 'mpeg2',   # MPEG-2 - DVDやデジタルテレビ放送で使用されるビデオコーデック
-    '8': 'mpeg1',   # MPEG-1 - VCDや初期のデジタルビデオカメラで使用
-    '9': 'xvid',    # Xvid - MPEG-4 Part 2のオープンソース実装、広くサポートされている
-}
-
-# easy_setting が True の場合のフォーマットマッピング
-EASY_FORMAT_MAP = {
+FORMAT_MAP = {
     '0': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]',  # デフォルト
     '1': 'bestvideo[ext=mp4][height=144]+bestaudio[ext=m4a]/best[ext=mp4]',
     '2': 'bestvideo[ext=mp4][height=240]+bestaudio[ext=m4a]/best[ext=mp4]',
@@ -79,11 +11,3 @@ EASY_FORMAT_MAP = {
     '7': 'bestvideo[ext=mp4][height=2160]+bestaudio[ext=m4a]/best[ext=mp4]',
     'a': 'bestaudio[ext=m4a]/bestaudio/best',  # 音声のみ
 }
-
-def build_format_string(video_format=None, resolution=None, audio_format=None, audio_quality=None, codec=None):
-    if video_format and resolution and audio_format and audio_quality and codec:
-        format_str = f"bestvideo[ext={video_format}][vcodec={codec}][height={resolution}]+bestaudio[ext={audio_format}][acodec=aac]/best[ext={video_format}]"
-        return format_str
-    else:
-        # デフォルト
-        return EASY_FORMAT_MAP.get('0')

--- a/utl2_video_downloader.py
+++ b/utl2_video_downloader.py
@@ -3,7 +3,7 @@
 import os
 import yt_dlp
 
-from utl2_1_format_map import EASY_FORMAT_MAP, build_format_string, VIDEO_FORMATS, VIDEO_RESOLUTIONS, AUDIO_FORMATS, AUDIO_QUALITIES, CODECS
+from utl2_1_format_map import FORMAT_MAP
 
 # ------------------------------------------------------------------
 # 指定されたYouTube動画をダウンロードし、メタデータを生成します。
@@ -26,36 +26,9 @@ def download_video(video_url, download_dir, format_code):
     # ---------------------------
     # 1. フォーマットの設定
     # ---------------------------
-    if len(format_code) == 1 and format_code in EASY_FORMAT_MAP:
-        # easy_setting: 簡単設定を使用
-        selected_format = EASY_FORMAT_MAP[format_code]
+    if  format_code in FORMAT_MAP: 
+        selected_format = FORMAT_MAP[format_code]
         print(f"Easy setting: 使用フォーマットコード '{format_code}' を選択")
-        print(f"選択されたフォーマット: {selected_format}")
-    elif len(format_code) == 5:
-        # 詳細設定: 5桁のフォーマットコード
-        video_format_code  = format_code[0]
-        resolution_code    = format_code[1]
-        audio_format_code  = format_code[2]
-        audio_quality_code = format_code[3]
-        codec_code         = format_code[4]
-
-        video_format  = VIDEO_FORMATS.get(video_format_code)
-        resolution    = VIDEO_RESOLUTIONS.get(resolution_code)
-        audio_format  = AUDIO_FORMATS.get(audio_format_code)
-        audio_quality = AUDIO_QUALITIES.get(audio_quality_code)
-        codec         = CODECS.get(codec_code)
-
-        if not (video_format and resolution and audio_format and audio_quality and codec):
-            print(f"詳細設定のフォーマットコードが無効です: {format_code}")
-            return None
-
-        selected_format = build_format_string(video_format, resolution, audio_format, audio_quality, codec)
-        print(f"詳細設定: 使用フォーマットコード '{format_code}' を選択")
-        print(f"動画形式: {video_format} ({video_format_code})")
-        print(f"動画画質: {resolution}p ({resolution_code})")
-        print(f"音声形式: {audio_format} ({audio_format_code})")
-        print(f"音声の音質: {audio_quality} ({audio_quality_code})")
-        print(f"コーデック: {codec} ({codec_code})")
         print(f"選択されたフォーマット: {selected_format}")
     else:
         print(f"無効なフォーマットコードです: {format_code}")


### PR DESCRIPTION
format_stringを用いた画質、動画コーデック、音質、音質コーデック、出力コーデックなどの詳細な設定を処理しました。
処理した理由は、144pなどに設定しても動画コーデックや出力コーデックが対応していないものもあるため。
汎用性の高いmp4, m4a, mp4で画質のみをFORMAT_MAP内で自書式に設定するようにした。

ttl_merge.py : 
必要なくなったeasy_settingを削除。
format_code判定の三項演算子を削除、ただ変数代入だけにした。


utl2_video_downloader.py : 
utl2_1からのimportをFORMAT_MAPのみ変更。
フォーマットコード判定・フォーマットコード解析を削除。

utl2_1_format_map.py : 
EASY_FORMAT_MAP -> FORMAT_MAPに変更。
他のマッピング、build_format_string関数を削除。